### PR TITLE
Initial step rate for rprop

### DIFF
--- a/climin/rprop.py
+++ b/climin/rprop.py
@@ -132,18 +132,11 @@ class Rprop(Minimizer):
         for args, kwargs in self.args:
             gradient_m1 = self.gradient
             self.gradient = self.fprime(self.wrt, *args, **kwargs)
-            changes_min = self.changes * self.step_grow
-            changes_max = self.changes * self.step_shrink
-            gradprod = gradient_m1 * self.gradient
-            changes_min *= gradprod > 0
-            changes_max *= gradprod < 0
-            self.changes *= gradprod == 0
-
-            # TODO actually, this should be done to changes
-            changes_min = ma.clip(changes_min, self.min_step, self.max_step)
-            changes_max = ma.clip(changes_max, self.min_step, self.max_step)
-
-            self.changes += changes_min + changes_max
+            
+            self.changes[gradprod>0] *= self.step_grow
+            self.changes[gradprod<0] *= self.step_shrink
+            self.changes = ma.clip(self.changes, self.min_step, self.max_step)
+    
             step = -self.changes * ma.sign(self.gradient)
             self.wrt += step
 

--- a/climin/rprop.py
+++ b/climin/rprop.py
@@ -74,13 +74,16 @@ class Rprop(Minimizer):
 
     max_step : float
         Maximum step rate.
+
+    init_step : float
+        Initial step rate.
     """
 
     state_fields = ('n_iter step_shrink step_grow min_step max_step '
                     'changes gradient').split()
 
     def __init__(self, wrt, fprime, step_shrink=0.5, step_grow=1.2,
-                 min_step=1E-6, max_step=1, changes_max=0.1, args=None):
+                 min_step=1E-6, max_step=1, init_step=0.0125, args=None):
         """Create an Rprop object.
 
         Parameters
@@ -108,6 +111,9 @@ class Rprop(Minimizer):
         max_step : float
             Maximum step rate.
 
+        init_step : float
+            Initial step rate.
+
         args : iterable
             Iterator over arguments which ``fprime`` will be called with.
         """
@@ -118,10 +124,9 @@ class Rprop(Minimizer):
         self.step_grow = step_grow
         self.min_step = min_step
         self.max_step = max_step
-        self.changes_max = changes_max
 
         self.gradient = ma.zero_like(self.wrt)
-        self.changes = ma.zero_like(self.wrt)
+        self.changes = ma.zero_like(self.wrt) + init_step
 
     def _iterate(self):
         for args, kwargs in self.args:


### PR DESCRIPTION
introducing an initial step rate as recommended for irprop- fixes the slow start. in some cases it was barely usable, as getting from min_step to a decent step rate takes forever.
i also removed the changes_max parameter as it was never used.
