### PR TITLE
Import fixes for python 3.4

### DIFF
--- a/climin/__init__.py
+++ b/climin/__init__.py
@@ -1,9 +1,9 @@
-from bfgs import Bfgs, Lbfgs, Sbfgs
-from cg import ConjugateGradient, NonlinearConjugateGradient
-from gd import GradientDescent
-from nes import Xnes
-from rmsprop import RmsProp
-from rprop import Rprop
-from smd import Smd
-from asgd import Asgd
-from adadelta import Adadelta
+from .bfgs import Bfgs, Lbfgs, Sbfgs
+from .cg import ConjugateGradient, NonlinearConjugateGradient
+from .gd import GradientDescent
+from .nes import Xnes
+from .rmsprop import RmsProp
+from .rprop import Rprop
+from .smd import Smd
+from .asgd import Asgd
+from .adadelta import Adadelta

--- a/climin/adadelta.py
+++ b/climin/adadelta.py
@@ -3,8 +3,8 @@
 """This module provides an implementation of adadelta."""
 
 
-from base import Minimizer
-from mathadapt import sqrt, ones_like, clip
+from .base import Minimizer
+from .mathadapt import sqrt, ones_like, clip
 
 
 class Adadelta(Minimizer):

--- a/climin/asgd.py
+++ b/climin/asgd.py
@@ -3,7 +3,7 @@
 # TODO: document module
 # TODO: check if gnumpy compatible
 
-from base import Minimizer
+from .base import Minimizer
 
 
 class Asgd(Minimizer):

--- a/climin/bfgs.py
+++ b/climin/bfgs.py
@@ -39,8 +39,8 @@ import numpy as np
 import scipy.linalg
 import scipy.optimize
 
-from base import Minimizer, is_nonzerofinite
-from linesearch import WolfeLineSearch
+from .base import Minimizer, is_nonzerofinite
+from .linesearch import WolfeLineSearch
 
 
 class Bfgs(Minimizer):

--- a/climin/cg.py
+++ b/climin/cg.py
@@ -39,8 +39,8 @@ import numpy as np
 import scipy.linalg
 import scipy.optimize
 
-from base import Minimizer, is_nonzerofinite
-from linesearch import WolfeLineSearch
+from .base import Minimizer, is_nonzerofinite
+from .linesearch import WolfeLineSearch
 
 
 class ConjugateGradient(Minimizer):

--- a/climin/gd.py
+++ b/climin/gd.py
@@ -4,7 +4,7 @@
 """This module provides an implementation of gradient descent."""
 
 
-from base import Minimizer
+from .base import Minimizer
 
 
 class GradientDescent(Minimizer):

--- a/climin/initialize.py
+++ b/climin/initialize.py
@@ -7,7 +7,7 @@ import random
 
 import numpy as np
 
-import climin.mathadapt as ma
+import .mathadapt as ma
 
 
 def sparsify_columns(arr, n_non_zero, keep_diagonal=False):

--- a/climin/nes.py
+++ b/climin/nes.py
@@ -32,7 +32,7 @@
 import scipy
 import scipy.linalg
 
-from base import Minimizer
+from .base import Minimizer
 
 
 class Xnes(Minimizer):

--- a/climin/project.py
+++ b/climin/project.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 
-from mathadapt import sqrt
+from .mathadapt import sqrt
 
 
 def max_length_columns(arr, max_length):

--- a/climin/rmsprop.py
+++ b/climin/rmsprop.py
@@ -5,8 +5,8 @@
 
 import numpy as np
 
-from base import Minimizer
-from mathadapt import sqrt, ones_like, clip
+from .base import Minimizer
+from .mathadapt import sqrt, ones_like, clip
 
 
 class RmsProp(Minimizer):

--- a/climin/rprop.py
+++ b/climin/rprop.py
@@ -4,9 +4,9 @@
 
 
 
-import mathadapt as ma
+from . import mathadapt as ma
 
-from base import Minimizer
+from .base import Minimizer
 
 
 class Rprop(Minimizer):

--- a/climin/smd.py
+++ b/climin/smd.py
@@ -6,7 +6,7 @@ import warnings
 
 import numpy as np
 
-from base import Minimizer, is_nonzerofinite
+from .base import Minimizer, is_nonzerofinite
 
 
 class Smd(Minimizer):

--- a/climin/util.py
+++ b/climin/util.py
@@ -8,12 +8,12 @@ import warnings
 
 import numpy as np
 
-from gd import GradientDescent
-from bfgs import Lbfgs
-from cg import NonlinearConjugateGradient
-from rprop import Rprop
-from rmsprop import RmsProp
-from adadelta import Adadelta
+from .gd import GradientDescent
+from .bfgs import Lbfgs
+from .cg import NonlinearConjugateGradient
+from .rprop import Rprop
+from .rmsprop import RmsProp
+from .adadelta import Adadelta
 
 try:
     from sklearn.grid_search import ParameterSampler


### PR DESCRIPTION
Fixes the import so climin can be installed on python 3.4. The test files still need some attention, but the installation works.