### PR TITLE
adjusted TimeElapsed for interruptions

### DIFF
--- a/climin/stops/stops.py
+++ b/climin/stops/stops.py
@@ -147,7 +147,10 @@ class TimeElapsed(object):
         self.start = time.time()
 
     def __call__(self, info):
-        return info.get('time', time.time()) - self.start > self.sec
+        if 'runtime' in info:
+            return info['runtime'] > self.sec
+        else:
+            return time.time() - self.start > self.sec
 
 
 def All(criterions):

--- a/climin/stops/stops.py
+++ b/climin/stops/stops.py
@@ -132,6 +132,10 @@ class TimeElapsed(object):
     >>> time.sleep(0.5)
     >>> stop({})
     True
+    >>> stop2 = S.TimeElapsed(10); stop2({'runtime': 9})
+    False
+    >>> stop3 = S.TimeElapsed(10); stop2({'runtime': 11})
+    True
     """
 
     def __init__(self, sec):

--- a/climin/stops/stops.py
+++ b/climin/stops/stops.py
@@ -147,7 +147,7 @@ class TimeElapsed(object):
         self.start = time.time()
 
     def __call__(self, info):
-        return time.time() - self.start > self.sec
+        return info.get('time', time.time()) - self.start > self.sec
 
 
 def All(criterions):


### PR DESCRIPTION
previously, TimeElapsed would simply calculate time from its
instantiation, which is problematic if the experiment is interrupted thereafter. Now it can read out the info dict which can hold a more
meaningful runtime value.