### PR TITLE
Update signal handler fix for newer numpy/Anaconda version

### DIFF
--- a/climin/__init__.py
+++ b/climin/__init__.py
@@ -1,19 +1,29 @@
 from __future__ import absolute_import
 
-# What follows is part of a hack to make control breaking work on windows even
-# if scipy.stats ims imported. See:
-# http://stackoverflow.com/questions/15457786/ctrl-c-crashes-python-after-importing-scipy-stats and
-# https://github.com/numpy/numpy/issues/6923
+# Control breaking does not work on Windows after e.g. scipy.stats is
+# imported because certain Fortran libraries register their own signal handler
+# See:
+# http://stackoverflow.com/questions/15457786/ctrl-c-crashes-python-after-importing-scipy-stats
+# and https://github.com/numpy/numpy/issues/6923
 import sys
 import os
 import imp
 import ctypes
 
 if sys.platform == 'win32':
-    basepath = imp.find_module('numpy')[1]
+    # For setups where Intel Fortran compiler version >= 16.0 (This is the case
+    # for Anaconda version 4.1.5 which comes with numpy version 1.10.4) is used,
+    # the following flag allows to disable the additionally introduced signal
+    # handler, older versios make no use of this environment variable
     env = 'FOR_DISABLE_CONSOLE_CTRL_HANDLER'
     if env not in os.environ:
         os.environ[env] = '1'
+    # In setups with an older version, ensuring that the respective dlls are
+    # loaded from the numpy core and not somewhere else (e.g. the Windows System
+    # folder) helps
+    basepath = imp.find_module('numpy')[1]
+    # dll loading fails when Intel Fortran compiler version >= 16.0, therefore
+    # use try/catch
     try:
         ctypes.CDLL(os.path.join(basepath, 'core', 'libmmd.dll'))
         ctypes.CDLL(os.path.join(basepath, 'core', 'libifcoremd.dll'))

--- a/climin/__init__.py
+++ b/climin/__init__.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 
 # What follows is part of a hack to make control breaking work on windows even
 # if scipy.stats ims imported. See:
-# http://stackoverflow.com/questions/15457786/ctrl-c-crashes-python-after-importing-scipy-stats
+# http://stackoverflow.com/questions/15457786/ctrl-c-crashes-python-after-importing-scipy-stats and
+# https://github.com/numpy/numpy/issues/6923
 import sys
 import os
 import imp
@@ -10,8 +11,14 @@ import ctypes
 
 if sys.platform == 'win32':
     basepath = imp.find_module('numpy')[1]
-    ctypes.CDLL(os.path.join(basepath, 'core', 'libmmd.dll'))
-    ctypes.CDLL(os.path.join(basepath, 'core', 'libifcoremd.dll'))
+    env = 'FOR_DISABLE_CONSOLE_CTRL_HANDLER'
+    if env not in os.environ:
+        os.environ[env] = '1'
+    try:
+        ctypes.CDLL(os.path.join(basepath, 'core', 'libmmd.dll'))
+        ctypes.CDLL(os.path.join(basepath, 'core', 'libifcoremd.dll'))
+    except Exception:
+        pass
 
 from .adadelta import Adadelta
 from .adam import Adam


### PR DESCRIPTION
A newer Anaconda version (tested with 4.1.5) comes with numpy version 1.10.4 which uses newer Fortran compilers. The old fix fails, but the newly introduced flag `'FOR_DISABLE_CONSOLE_CTRL_HANDLER'` (Intel Fortran version >=16.0) can be utilized instead for preventing breaking of Ctrl+C/Break. 