### PR TITLE
Update adam

### DIFF
--- a/climin/adam.py
+++ b/climin/adam.py
@@ -26,10 +26,9 @@ class Adam(Minimizer):
 
     Let :math:`f_t'(\\theta_t)` be the derivative of the loss with respect to
     the parameters at time step :math:`t`. In its
-    basic form, given a step rate :math:`\\alpha`, a decay term
-    :math:`\\lambda`, decay terms :math:``\\beta_1`` and :math:``\\beta_2`` for
-    the first and seconed moment estimates repsectively and an offset
-    :math:`\\epsilon` we initialise the following quantities
+    basic form, given a step rate :math:`\\alpha`, decay terms :math:`\\beta_1`
+    and :math:`\\beta_2` for the first and second moment estimates respectively
+    and an offset :math:`\\epsilon` we initialise the following quantities
 
     .. math::
        m_0 & \\leftarrow 0 \\\\
@@ -40,9 +39,8 @@ class Adam(Minimizer):
 
     .. math::
         t     & \\leftarrow t + 1 \\\\
-        \\beta_{1, t} & \\leftarrow 1 - (1 - \\beta_1)\\lambda^{t-1} \\\\
         g_t   & \\leftarrow f_t'(\\theta_{t-1}) \\\\
-        m_t   & \\leftarrow \\beta_{1,t} \cdot g_t + (1 - \\beta_{1, t}) \cdot m_{t-1} \\\\
+        m_t   & \\leftarrow \\beta_1 \cdot g_t + (1 - \\beta_1) \cdot m_{t-1} \\\\
         v_t   &\\leftarrow  \\beta_2 \cdot g_t^2 + (1 - \\beta_2) \cdot v_{t-1}
 
         \\hat{m}_t  &\\leftarrow {m_t \\over (1 - (1 - \\beta_1)^t)} \\\\
@@ -64,18 +62,30 @@ class Adam(Minimizer):
     :math:`\\beta_1`         ``decay_mom1``      Exponential decay parameter for first moment estimate.
     :math:`\\beta_2`         ``decay_mom2``      Exponential decay parameter for second moment estimate.
     :math:`\\epsilon`        ``offset``          Safety offset for division by estimate of second moment.
-    :math:`\\lambda`         ``decay``           n/a
     ======================= =================== ===========================================================
+
+    Additionally, using Nesterov momentum is possible by setting the momentum
+    attribute of the optimizer to a value other than 0. We apply the momentum
+    step before computing the gradient, resulting in a similar incorporation of
+    Nesterov momentum in Adam as presented in [nadam2015]_.
+
+    .. note::
+       The use of decay parameters :math:`\\beta_1` and :math:`\\beta_2` differs
+       from the definition in the original paper [adam2014]_:
+       With :math:`\\beta^{\\ast}_i` referring to the parameters as defined in
+       the paper, we use with :math:`\\beta_i = 1 - \\beta^{\\ast}_i`
 
     .. [adam2014] Kingma, Diederik, and Jimmy Ba.
        "Adam: A Method for Stochastic Optimization."
        arXiv preprint arXiv:1412.6980 (2014).
+    .. [nadam2015] Dozat, Timothy
+       "Incorporating Nesterov Momentum into Adam."
+       Stanford University, Tech. Rep (2015).
     """
 
-    state_fields = 'n_iter step_rate decay decay_mom1 decay_mom2 step offset est_mom1_b est_mom2_b'.split()
+    state_fields = 'n_iter step_rate decay_mom1 decay_mom2 step offset est_mom1_b est_mom2_b'.split()
 
     def __init__(self, wrt, fprime, step_rate=.0002,
-                 decay=1-1e-8,
                  decay_mom1=0.1,
                  decay_mom2=0.001,
                  momentum=0,
@@ -98,10 +108,6 @@ class Adam(Minimizer):
             Value to multiply steps with before they are applied to the
             parameter vector.
 
-        decay : float, optional [default: 1e-8]
-            Decay parameter for the moving average. Must lie in [0, 1) where
-            lower numbers means a shorter "memory".
-
         decay_mom1 : float, optional, [default: 0.1]
             Decay parameter for the exponential moving average estimate of the
             first moment.
@@ -111,8 +117,8 @@ class Adam(Minimizer):
             second moment.
 
         momentum : float or array_like, optional [default: 0]
-          Momentum to use during optimization. Can be specified analoguously
-          (but independent of) step rate.
+            Momentum to use during optimization. Can be specified analogously
+            (but independent of) step rate.
 
         offset : float, optional, [default: 1e-8]
             Before taking the square root of the running averages, this offset
@@ -121,8 +127,6 @@ class Adam(Minimizer):
         args : iterable
             Iterator over arguments which ``fprime`` will be called with.
         """
-        if not 0 < decay < 1:
-            raise ValueError('decay has to lie in (0, 1)')
         if not 0 < decay_mom1 <= 1:
             raise ValueError('decay_mom1 has to lie in (0, 1]')
         if not 0 < decay_mom2 <= 1:
@@ -136,7 +140,6 @@ class Adam(Minimizer):
 
         self.fprime = fprime
         self.step_rate = step_rate
-        self.decay = decay
         self.decay_mom1 = decay_mom1
         self.decay_mom2 = decay_mom2
         self.offset = offset
@@ -150,28 +153,26 @@ class Adam(Minimizer):
     def _iterate(self):
         for args, kwargs in self.args:
             m = self.momentum
-            d = self.decay
             dm1 = self.decay_mom1
             dm2 = self.decay_mom2
             o = self.offset
             t = self.n_iter + 1
 
             step_m1 = self.step
-            step1 = step_m1 * m * self.step_rate
+            step1 = step_m1 * m
             self.wrt -= step1
 
             est_mom1_b_m1 = self.est_mom1_b
             est_mom2_b_m1 = self.est_mom2_b
 
-            coeff1 = 1 - (1 - dm1) * d ** (t - 1)
             gradient = self.fprime(self.wrt, *args, **kwargs)
-            self.est_mom1_b = coeff1 * gradient + (1 - coeff1) * est_mom1_b_m1
+            self.est_mom1_b = dm1 * gradient + (1 - dm1) * est_mom1_b_m1
             self.est_mom2_b = dm2 * gradient ** 2 + (1 - dm2) * est_mom2_b_m1
 
             self.est_mom1 = self.est_mom1_b / (1 - (1 - dm1) ** t + o)
             self.est_mom2 = self.est_mom2_b / (1 - (1 - dm2) ** t + o)
 
-            step2 = self.step_rate * self.est_mom1 / ((self.est_mom2) ** 0.5 + o)
+            step2 = self.step_rate * self.est_mom1 / (self.est_mom2 ** 0.5 + o)
 
             self.wrt -= step2
             self.step = step1 + step2

--- a/climin/adam.py
+++ b/climin/adam.py
@@ -86,6 +86,7 @@ class Adam(Minimizer):
     state_fields = 'n_iter step_rate decay_mom1 decay_mom2 step offset est_mom1_b est_mom2_b'.split()
 
     def __init__(self, wrt, fprime, step_rate=.0002,
+                 decay=None,
                  decay_mom1=0.1,
                  decay_mom2=0.001,
                  momentum=0,
@@ -135,6 +136,9 @@ class Adam(Minimizer):
             warnings.warn("constraint from convergence analysis for adam not "
                           "satisfied; check original paper to see if you "
                           "really want to do this.")
+        if decay is not None:
+            warnings.warn('decay parameter was used in a previous verion of '
+                          'Adam and no longer has any effect.')
 
         super(Adam, self).__init__(wrt, args=args)
 


### PR DESCRIPTION
The decay parameter is no longer included in the original adam paper anymore (was apparently only needed for a convergence proof), thus it is set to None and a warning is issued if the user deliberately sets it to another value. Also fixes a bug in the (nesterov) momentum step and includes an optimization mentioned in the adam paper.